### PR TITLE
increase nmp reduction by static eval margin over beta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -15,11 +15,17 @@ struct Searcher {
     int negamax(Board &board, Move &bestmv, int16_t alpha, int16_t beta, int16_t depth, int ply) {
         int pv = beta > alpha+1;
 
-        if (!pv && board.eval() >= beta && depth > 1) {
+        int static_eval = board.eval();
+
+        if (!pv && static_eval >= beta && depth > 1) {            
             Board mkmove = board;
             mkmove.null_move();
+
+            int margin_reduction = (static_eval - beta) / 128;
+            if (margin_reduction > 2) margin_reduction = 2;
+
             Move scratch;
-            int v = -negamax(mkmove, scratch, -beta, -alpha, depth - 3, ply + 1);
+            int v = -negamax(mkmove, scratch, -beta, -alpha, depth - 3 - margin_reduction, ply + 1);
             if (v >= beta) {
                 return v;
             }
@@ -59,7 +65,7 @@ struct Searcher {
 
         int raised_alpha = 0;
 
-        int16_t best = depth > 0 ? LOST + ply : board.eval();
+        int16_t best = depth > 0 ? LOST + ply : static_eval;
         if (best >= beta) return best;
 
         int legals = 0;


### PR DESCRIPTION
```
ELO   | 23.62 +- 11.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2696 W: 1106 L: 923 D: 667
```
size: 3058
bench: 747484