### PR TITLE
change history using squared depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -160,11 +160,11 @@ struct Searcher {
                     for (int j = 0; j < i; j++) {
                         if (board.board[moves[j].to]) continue;
                         int16_t& hist = history[board.stm == BLACK][board.board[moves[j].from] & 7][moves[j].to-A1];
-                        int change = depth * 16;
+                        int change = depth * depth;
                         hist -= change + change * hist / MAX_HIST;
                     }
                     int16_t& hist = history[board.stm == BLACK][board.board[bestmv.from] & 7][bestmv.to-A1];
-                    int change = depth * 16;
+                    int change = depth * depth;
                     hist += change - change * hist / MAX_HIST;
                     if (!(killers[ply][0] == bestmv)) {
                         killers[ply][1] = killers[ply][0];


### PR DESCRIPTION
```
ELO   | 4.05 +- 3.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 31240 W: 11226 L: 10862 D: 9152
```
size: 3344
bench: 17235715